### PR TITLE
Fix `external_id` property on `RegistryProject` and minor refactors

### DIFF
--- a/flame_hub/_core_client.py
+++ b/flame_hub/_core_client.py
@@ -488,9 +488,6 @@ class CoreClient(BaseClient):
         return self._get_single_resource(Analysis, "analyses", analysis_id)
 
     def update_analysis(self, analysis_id: Analysis | uuid.UUID | str, name: str = _UNSET) -> Analysis:
-        if analysis_id not in (None, _UNSET):
-            analysis_id = obtain_uuid_from(analysis_id)
-
         return self._update_resource(Analysis, UpdateAnalysis(name=name), "analyses", analysis_id)
 
     def send_analysis_command(self, analysis_id: Analysis | uuid.UUID | str, command: AnalysisCommand):
@@ -573,9 +570,6 @@ class CoreClient(BaseClient):
     def update_analysis_bucket_file(
         self, analysis_bucket_file_id: AnalysisBucketFile | uuid.UUID | str, is_entrypoint: bool = _UNSET
     ) -> AnalysisBucketFile:
-        if analysis_bucket_file_id not in (None, _UNSET):
-            analysis_bucket_file_id = obtain_uuid_from(analysis_bucket_file_id)
-
         return self._update_resource(
             AnalysisBucketFile,
             UpdateAnalysisBucketFile(root=is_entrypoint),

--- a/flame_hub/_core_client.py
+++ b/flame_hub/_core_client.py
@@ -178,9 +178,7 @@ class AnalysisNode(CreateAnalysisNode):
     artifact_digest: str | None
     created_at: datetime
     updated_at: datetime
-    analysis_id: uuid.UUID
     analysis_realm_id: uuid.UUID
-    node_id: uuid.UUID
     node_realm_id: uuid.UUID
 
 

--- a/flame_hub/_core_client.py
+++ b/flame_hub/_core_client.py
@@ -60,6 +60,11 @@ class MasterImageGroup(BaseModel):
     updated_at: datetime
 
 
+class MasterImageCommandArgument(te.TypedDict):
+    value: str
+    position: t.Literal["before", "after"] | None
+
+
 class MasterImage(BaseModel):
     id: uuid.UUID
     path: str | None
@@ -67,6 +72,7 @@ class MasterImage(BaseModel):
     group_virtual_path: str
     name: str
     command: str | None
+    command_arguments: list[MasterImageCommandArgument] | None
     created_at: datetime
     updated_at: datetime
 
@@ -138,6 +144,7 @@ class CreateAnalysis(BaseModel):
     project_id: uuid.UUID
     master_image_id: uuid.UUID | None
     registry_id: uuid.UUID | None
+    image_command_arguments: list[MasterImageCommandArgument] = []
 
 
 class Analysis(CreateAnalysis):
@@ -159,6 +166,7 @@ class UpdateAnalysis(UpdateModel):
     description: str | None = None
     name: str | None = None
     master_image_id: uuid.UUID | None = None
+    image_command_arguments: list[MasterImageCommandArgument] | None = None
 
 
 AnalysisCommand = t.Literal["spinUp", "tearDown", "buildStart", "buildStop", "configurationLock", "configurationUnlock"]
@@ -472,6 +480,7 @@ class CoreClient(BaseClient):
         description: str = None,
         master_image_id: MasterImage | uuid.UUID | str = None,
         registry_id: Registry | uuid.UUID | str = None,
+        image_command_arguments: list[MasterImageCommandArgument] = (),
     ) -> Analysis:
         if master_image_id is not None:
             master_image_id = obtain_uuid_from(master_image_id)
@@ -486,6 +495,7 @@ class CoreClient(BaseClient):
                 description=description,
                 master_image_id=master_image_id,
                 registry_id=registry_id,
+                image_command_arguments=image_command_arguments,
             ),
             "analyses",
         )
@@ -508,13 +518,19 @@ class CoreClient(BaseClient):
         name: str = _UNSET,
         description: str = _UNSET,
         master_image_id: MasterImage | uuid.UUID | str = _UNSET,
+        image_command_arguments: list[MasterImageCommandArgument] = _UNSET,
     ) -> Analysis:
         if master_image_id not in (None, _UNSET):
             master_image_id = obtain_uuid_from(master_image_id)
 
         return self._update_resource(
             Analysis,
-            UpdateAnalysis(name=name, description=description, master_image_id=master_image_id),
+            UpdateAnalysis(
+                name=name,
+                description=description,
+                master_image_id=master_image_id,
+                image_command_arguments=image_command_arguments,
+            ),
             "analyses",
             analysis_id,
         )

--- a/flame_hub/_core_client.py
+++ b/flame_hub/_core_client.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import httpx
 import typing_extensions as te
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from flame_hub._auth_client import Realm
 from flame_hub._base_client import (
@@ -166,7 +166,7 @@ class UpdateAnalysis(UpdateModel):
     description: str | None = None
     name: str | None = None
     master_image_id: uuid.UUID | None = None
-    image_command_arguments: list[MasterImageCommandArgument] | None = None
+    image_command_arguments: t.Annotated[list[MasterImageCommandArgument], Field(default_factory=list)]
 
 
 AnalysisCommand = t.Literal["spinUp", "tearDown", "buildStart", "buildStop", "configurationLock", "configurationUnlock"]

--- a/flame_hub/_core_client.py
+++ b/flame_hub/_core_client.py
@@ -27,7 +27,7 @@ class CreateNode(BaseModel):
     external_name: str | None
     hidden: bool | None
     name: str
-    realm_id: uuid.UUID
+    realm_id: uuid.UUID | None
     registry_id: uuid.UUID | None
     type: NodeType | None
 

--- a/flame_hub/_core_client.py
+++ b/flame_hub/_core_client.py
@@ -271,7 +271,7 @@ class CreateRegistryProject(BaseModel):
 class RegistryProject(CreateRegistryProject):
     id: uuid.UUID
     public: bool
-    external_id: uuid.UUID | None
+    external_id: str | None
     webhook_name: str | None
     webhook_exists: bool | None
     realm_id: uuid.UUID | None

--- a/flame_hub/_core_client.py
+++ b/flame_hub/_core_client.py
@@ -500,7 +500,9 @@ class CoreClient(BaseClient):
         self, analysis_id: Analysis | uuid.UUID | str, node_id: Node | uuid.UUID | str
     ) -> AnalysisNode:
         return self._create_resource(
-            AnalysisNode, CreateAnalysisNode(analysis_id=analysis_id, node_id=node_id), "analysis-nodes"
+            AnalysisNode,
+            CreateAnalysisNode(analysis_id=obtain_uuid_from(analysis_id), node_id=obtain_uuid_from(node_id)),
+            "analysis-nodes",
         )
 
     def delete_analysis_node(self, analysis_node_id: AnalysisNode | uuid.UUID | str):

--- a/flame_hub/_core_client.py
+++ b/flame_hub/_core_client.py
@@ -596,6 +596,11 @@ class CoreClient(BaseClient):
     ) -> AnalysisBucketFile | None:
         return self._get_single_resource(AnalysisBucketFile, "analysis-bucket-files", analysis_bucket_file_id)
 
+    def delete_analysis_bucket_file(
+        self, analysis_bucket_file_id: AnalysisBucketFile | uuid.UUID | str
+    ) -> AnalysisBucketFile | None:
+        self._delete_resource("analysis-bucket-files", analysis_bucket_file_id)
+
     def create_analysis_bucket_file(
         self,
         name: str,

--- a/flame_hub/_core_client.py
+++ b/flame_hub/_core_client.py
@@ -27,7 +27,7 @@ class CreateNode(BaseModel):
     external_name: str | None
     hidden: bool | None
     name: str
-    realm_id: uuid.UUID | None
+    realm_id: uuid.UUID
     registry_id: uuid.UUID | None
     type: NodeType | None
 


### PR DESCRIPTION
Fix that the `external_id` attribute of `RegistryProject`can be any string.

fixes #24 