### PR TITLE
Extended analysis commands

### DIFF
--- a/flame_hub/_core_client.py
+++ b/flame_hub/_core_client.py
@@ -603,11 +603,13 @@ class CoreClient(BaseClient):
             analysis_id,
         )
 
-    def send_analysis_command(self, analysis_id: Analysis | uuid.UUID | str, command: AnalysisCommand):
+    def send_analysis_command(self, analysis_id: Analysis | uuid.UUID | str, command: AnalysisCommand) -> Analysis:
         r = self._client.post(f"analyses/{obtain_uuid_from(analysis_id)}/command", json={"command": command})
 
         if r.status_code != httpx.codes.ACCEPTED.value:
             raise new_hub_api_error_from_response(r)
+
+        return Analysis(**r.json())
 
     def create_analysis_node(
         self, analysis_id: Analysis | uuid.UUID | str, node_id: Node | uuid.UUID | str

--- a/flame_hub/_core_client.py
+++ b/flame_hub/_core_client.py
@@ -248,7 +248,15 @@ class UpdateAnalysis(UpdateModel):
     image_command_arguments: t.Annotated[list[MasterImageCommandArgument], Field(default_factory=list)]
 
 
-AnalysisCommand = t.Literal["spinUp", "tearDown", "buildStart", "buildStop", "configurationLock", "configurationUnlock"]
+AnalysisCommand = t.Literal[
+    "spinUp",
+    "tearDown",
+    "buildStart",
+    "buildStop",
+    "configurationLock",
+    "configurationUnlock",
+    "buildStatus",
+]
 
 
 class AnalysisLog(BaseModel):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -348,22 +348,21 @@ def test_update_analysis(core_client, analysis):
 
 
 def test_lock_analysis(core_client, configured_analysis):
-    core_client.send_analysis_command(configured_analysis.id, command="configurationLock")
-    assert core_client.get_analysis(configured_analysis.id).configuration_locked is True
-
-    core_client.send_analysis_command(configured_analysis.id, command="configurationUnlock")
-    assert core_client.get_analysis(configured_analysis.id).configuration_locked is False
+    assert (
+        core_client.send_analysis_command(configured_analysis.id, command="configurationLock").configuration_locked
+        is True
+    )
+    assert (
+        core_client.send_analysis_command(configured_analysis.id, command="configurationUnlock").configuration_locked
+        is False
+    )
 
 
 def test_build_analysis(core_client, configured_analysis):
     core_client.send_analysis_command(configured_analysis.id, command="configurationLock")
-    core_client.send_analysis_command(configured_analysis.id, command="buildStart")
 
-    assert core_client.get_analysis(configured_analysis.id).build_status in ("starting", "started")
-
-    core_client.send_analysis_command(configured_analysis.id, command="buildStop")
-
-    assert core_client.get_analysis(configured_analysis.id).build_status in ("stopping", "stopped")
+    assert core_client.send_analysis_command(configured_analysis.id, command="buildStart").build_status == "starting"
+    assert core_client.send_analysis_command(configured_analysis.id, command="buildStop").build_status == "stopping"
 
 
 def test_build_status_analysis(core_client, configured_analysis):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -153,12 +153,12 @@ def configured_analysis(core_client, registry, analysis, master_realm, analysis_
         nodes.append(new_node)
         core_client.create_project_node(analysis.project_id, new_node)
         core_client.create_analysis_node(analysis, new_node)
+    core_client.send_analysis_command(analysis.id, command="configurationLock")
     return analysis
 
 
 @pytest.fixture()
 def analysis_log(core_client, configured_analysis):
-    core_client.send_analysis_command(configured_analysis, "configurationLock")
     core_client.send_analysis_command(configured_analysis, "buildStart")
 
     def _check_analysis_logs_present():
@@ -347,26 +347,23 @@ def test_update_analysis(core_client, analysis):
     assert new_analysis.name == new_name
 
 
-def test_lock_analysis(core_client, configured_analysis):
-    assert (
-        core_client.send_analysis_command(configured_analysis.id, command="configurationLock").configuration_locked
-        is True
-    )
+def test_unlock_analysis(core_client, configured_analysis):
     assert (
         core_client.send_analysis_command(configured_analysis.id, command="configurationUnlock").configuration_locked
         is False
     )
+    assert (
+        core_client.send_analysis_command(configured_analysis.id, command="configurationLock").configuration_locked
+        is True
+    )
 
 
 def test_build_analysis(core_client, configured_analysis):
-    core_client.send_analysis_command(configured_analysis.id, command="configurationLock")
-
     assert core_client.send_analysis_command(configured_analysis.id, command="buildStart").build_status == "starting"
     assert core_client.send_analysis_command(configured_analysis.id, command="buildStop").build_status == "stopping"
 
 
 def test_build_status_analysis(core_client, configured_analysis):
-    core_client.send_analysis_command(configured_analysis.id, command="configurationLock")
     core_client.send_analysis_command(configured_analysis.id, command="buildStart")
     core_client.send_analysis_command(configured_analysis.id, command="buildStatus")
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -140,7 +140,7 @@ def analysis_bucket_file(core_client, storage_client, analysis_buckets, rng_byte
 
 
 @pytest.fixture()
-def analysis_log(core_client, registry, analysis, master_realm, analysis_bucket_file):
+def configured_analysis(core_client, registry, analysis, master_realm, analysis_bucket_file):
     # An analysis needs at least one default and one aggregator node.
     nodes = []
     for node_type in t.get_args(NodeType):
@@ -153,15 +153,20 @@ def analysis_log(core_client, registry, analysis, master_realm, analysis_bucket_
         nodes.append(new_node)
         core_client.create_project_node(analysis.project_id, new_node)
         core_client.create_analysis_node(analysis, new_node)
-    core_client.send_analysis_command(analysis, "configurationLock")
-    core_client.send_analysis_command(analysis, "buildStart")
+    return analysis
+
+
+@pytest.fixture()
+def analysis_log(core_client, configured_analysis):
+    core_client.send_analysis_command(configured_analysis, "configurationLock")
+    core_client.send_analysis_command(configured_analysis, "buildStart")
 
     def _check_analysis_logs_present():
-        assert len(core_client.find_analysis_logs(filter={"analysis_id": analysis.id})) > 0
+        assert len(core_client.find_analysis_logs(filter={"analysis_id": configured_analysis.id})) > 0
 
     assert_eventually(_check_analysis_logs_present)
 
-    return core_client.find_analysis_logs(filter={"analysis_id": analysis.id})[0]
+    return core_client.find_analysis_logs(filter={"analysis_id": configured_analysis.id})[0]
 
 
 @pytest.fixture()
@@ -340,6 +345,14 @@ def test_update_analysis(core_client, analysis):
 
     assert analysis != new_analysis
     assert new_analysis.name == new_name
+
+
+def test_lock_analysis(core_client, configured_analysis):
+    core_client.send_analysis_command(configured_analysis.id, command="configurationLock")
+    assert core_client.get_analysis(configured_analysis.id).configuration_locked is True
+
+    core_client.send_analysis_command(configured_analysis.id, command="configurationUnlock")
+    assert core_client.get_analysis(configured_analysis.id).configuration_locked is False
 
 
 def test_analysis_node_update(core_client, analysis_node):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -355,6 +355,17 @@ def test_lock_analysis(core_client, configured_analysis):
     assert core_client.get_analysis(configured_analysis.id).configuration_locked is False
 
 
+def test_build_analysis(core_client, configured_analysis):
+    core_client.send_analysis_command(configured_analysis.id, command="configurationLock")
+    core_client.send_analysis_command(configured_analysis.id, command="buildStart")
+
+    assert core_client.get_analysis(configured_analysis.id).build_status in ("starting", "started")
+
+    core_client.send_analysis_command(configured_analysis.id, command="buildStop")
+
+    assert core_client.get_analysis(configured_analysis.id).build_status in ("stopping", "stopped")
+
+
 def test_build_status_analysis(core_client, configured_analysis):
     core_client.send_analysis_command(configured_analysis.id, command="configurationLock")
     core_client.send_analysis_command(configured_analysis.id, command="buildStart")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -355,6 +355,18 @@ def test_lock_analysis(core_client, configured_analysis):
     assert core_client.get_analysis(configured_analysis.id).configuration_locked is False
 
 
+def test_build_status_analysis(core_client, configured_analysis):
+    core_client.send_analysis_command(configured_analysis.id, command="configurationLock")
+    core_client.send_analysis_command(configured_analysis.id, command="buildStart")
+    core_client.send_analysis_command(configured_analysis.id, command="buildStatus")
+
+    def _check_checking_event_in_logs():
+        logs = core_client.find_analysis_logs(filter={"analysis_id": configured_analysis.id})
+        assert "checking" in [log.event for log in logs]
+
+    assert_eventually(_check_checking_event_in_logs)
+
+
 def test_analysis_node_update(core_client, analysis_node):
     new_analysis_node = core_client.update_analysis_node(analysis_node.id, run_status="starting")
 


### PR DESCRIPTION
- new `buildStatus` command
- `send_analysis_command()` now returns the updated analysis resource
- tests for every analysis command except `spinUp` and `tearDown`