### PR TITLE
Switch to trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -14,7 +14,25 @@ jobs:
         uses: ./.github/actions/setup-poetry
       - name: Install dependencies
         run: poetry install
-      - name: Build and publish
-        run: poetry publish --build --no-interaction
-        env:
-          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.POETRY_PYPI_TOKEN_PYPI }}
+      - name: Build package
+        run: poetry build --no-interaction
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          path: dist/
+          name: package-dist
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: build
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ github.workspace }}/dist/
+          name: package-dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Enable [trusted publishing](https://docs.pypi.org/trusted-publishers/) as specified in the PyPI docs. This allows us to publish package versions without having to provide credentials to our pipelines.

This splits up our workflow into two separate jobs: one for building and one for publishing. This is encouraged by the docs since the PyPI publish action modifies environment variables that other actions should not have access to. In this setup, there's only one interfering job.

Be aware that this is *not* tested but *should* work since I got [something similar working](https://github.com/JoogsWasTaken/eulenbude/blob/main/.github/workflows/deploy.yml) in a personal project of mine. We might have to trial-and-error this workflow a couple times until we're sure it works as it's supposed to.