### PR TITLE
Do not skip deployment on new release

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -27,7 +27,6 @@ jobs:
           path: docs/_build/html
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/_build/html


### PR DESCRIPTION
When a new version is released, `github.ref` is set to `refs/tags/v*`. In that case `if: github.ref == 'refs/heads/main'` prevents the deployment.